### PR TITLE
Fix Windows ROCm startup for llama.cpp

### DIFF
--- a/src/main/java/org/mark/llamacpp/server/LlamaCppProcess.java
+++ b/src/main/java/org/mark/llamacpp/server/LlamaCppProcess.java
@@ -2,11 +2,14 @@ package org.mark.llamacpp.server;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -103,6 +106,9 @@ public class LlamaCppProcess {
 			ProcessBuilder pb = new ProcessBuilder(args);
 
 			Map<String, String> env = pb.environment();
+			if (isWindows()) {
+				applyWindowsRuntimePath(pb, env);
+			}
 			String existingLdPath = env.get("LD_LIBRARY_PATH");
 
 			StringBuilder ldPathBuilder = new StringBuilder();
@@ -382,5 +388,113 @@ public class LlamaCppProcess {
 	private static boolean isWindows() {
 		String os = System.getProperty("os.name");
 		return os != null && os.toLowerCase(Locale.ROOT).contains("win");
+	}
+
+	private void applyWindowsRuntimePath(ProcessBuilder pb, Map<String, String> env) {
+		List<String> paths = new ArrayList<>();
+		addExistingDir(paths, this.llamaBinPath);
+
+		List<String> args = splitCommandLineArgs(this.cmd);
+		if (!args.isEmpty()) {
+			File exe = new File(args.get(0));
+			File exeDir = exe.getParentFile();
+			if (exeDir != null) {
+				addExistingDir(paths, exeDir.getAbsolutePath());
+				pb.directory(exeDir);
+			}
+		}
+
+		addWindowsRocmDirs(paths);
+		prependPath(env, paths);
+	}
+
+	private static void addWindowsRocmDirs(List<String> paths) {
+		File rocmRoot = new File("C:\\Program Files\\AMD\\ROCm");
+		File[] versions = rocmRoot.listFiles(File::isDirectory);
+		if (versions != null) {
+			Arrays.sort(versions, Comparator.comparing(File::getName).reversed());
+			for (File version : versions) {
+				addExistingDir(paths, new File(version, "bin").getAbsolutePath());
+				addExistingDir(paths, new File(version, "bin\\rocblas").getAbsolutePath());
+				addExistingDir(paths, new File(version, "bin\\hipblaslt").getAbsolutePath());
+			}
+		}
+
+		String[] fallbackRoots = {
+			"C:\\Program Files\\AMD\\AI_Bundle\\ROCm",
+			"C:\\Program Files\\AMD\\AI_Bundle"
+		};
+		for (String root : fallbackRoots) {
+			File dir = new File(root);
+			if (!dir.isDirectory()) {
+				continue;
+			}
+			addExistingDir(paths, new File(dir, "bin").getAbsolutePath());
+			addExistingDir(paths, new File(dir, "bin\\rocblas").getAbsolutePath());
+			addExistingDir(paths, new File(dir, "bin\\hipblaslt").getAbsolutePath());
+		}
+	}
+
+	private static void addExistingDir(List<String> paths, String path) {
+		if (path == null || path.isBlank()) {
+			return;
+		}
+		File dir = new File(path);
+		if (!dir.isDirectory()) {
+			return;
+		}
+		String abs = dir.getAbsolutePath();
+		for (String existing : paths) {
+			if (existing.equalsIgnoreCase(abs)) {
+				return;
+			}
+		}
+		paths.add(abs);
+	}
+
+	private static void prependPath(Map<String, String> env, List<String> paths) {
+		if (paths == null || paths.isEmpty()) {
+			return;
+		}
+		String key = findEnvKey(env, "PATH");
+		String current = key == null ? "" : env.getOrDefault(key, "");
+		StringBuilder merged = new StringBuilder();
+		for (String path : paths) {
+			if (current != null && containsPathIgnoreCase(current, path)) {
+				continue;
+			}
+			if (merged.length() > 0) {
+				merged.append(';');
+			}
+			merged.append(path);
+		}
+		if (current != null && !current.isBlank()) {
+			if (merged.length() > 0) {
+				merged.append(';');
+			}
+			merged.append(current);
+		}
+		env.put(key == null ? "PATH" : key, merged.toString());
+	}
+
+	private static String findEnvKey(Map<String, String> env, String key) {
+		for (String existing : env.keySet()) {
+			if (existing.equalsIgnoreCase(key)) {
+				return existing;
+			}
+		}
+		return null;
+	}
+
+	private static boolean containsPathIgnoreCase(String pathList, String path) {
+		if (pathList == null || path == null) {
+			return false;
+		}
+		for (String entry : pathList.split(";")) {
+			if (entry.trim().equalsIgnoreCase(path)) {
+				return true;
+			}
+		}
+		return false;
 	}
 }

--- a/src/main/java/org/mark/llamacpp/server/LlamaServerManager.java
+++ b/src/main/java/org/mark/llamacpp/server/LlamaServerManager.java
@@ -1250,6 +1250,9 @@ public class LlamaServerManager {
 			sb.append(' ');
 			sb.append(extraParams.trim());
 		}
+		if (isMtpSpeculative(allArgs) && !cmdHasFlag(allArgs, "--parallel")) {
+			sb.append(" --parallel 1");
+		}
 		if (chatTemplateFilePath != null && !chatTemplateFilePath.trim().isEmpty() && !cmdHasFlag(allArgs, "--chat-template-file") && !cmdHasFlag(allArgs, "--chat-template")) {
 			sb.append(" --chat-template-file ");
 			sb.append(ParamTool.quoteIfNeeded(chatTemplateFilePath.trim()));
@@ -1290,6 +1293,86 @@ public class LlamaServerManager {
 		String f = flag.trim();
 		String s = " " + cmd.trim() + " ";
 		return s.contains(" " + f + " ") || s.contains(" " + f + "=");
+	}
+
+	private boolean isMtpSpeculative(String cmd) {
+		if (cmd == null || cmd.trim().isEmpty()) {
+			return false;
+		}
+		List<String> args = splitCommandLineArgs(cmd);
+		for (int i = 0; i < args.size(); i++) {
+			String arg = args.get(i);
+			if ("--spec-type".equals(arg)) {
+				return i + 1 < args.size() && "mtp".equalsIgnoreCase(args.get(i + 1));
+			}
+			String prefix = "--spec-type=";
+			if (arg.regionMatches(true, 0, prefix, 0, prefix.length())) {
+				return "mtp".equalsIgnoreCase(arg.substring(prefix.length()));
+			}
+		}
+		return false;
+	}
+
+	private List<String> splitCommandLineArgs(String commandLine) {
+		List<String> out = new ArrayList<>();
+		if (commandLine == null) {
+			return out;
+		}
+		String s = commandLine.trim();
+		if (s.isEmpty()) {
+			return out;
+		}
+
+		StringBuilder cur = new StringBuilder();
+		boolean allowSingle = !isWindows();
+		boolean inSingle = false;
+		boolean inDouble = false;
+
+		for (int i = 0; i < s.length(); i++) {
+			char c = s.charAt(i);
+
+			if (inDouble && c == '\\') {
+				if (i + 1 < s.length() && s.charAt(i + 1) == '"') {
+					cur.append('"');
+					i++;
+					continue;
+				}
+				cur.append(c);
+				continue;
+			}
+			if (allowSingle && inSingle && c == '\\') {
+				if (i + 1 < s.length() && s.charAt(i + 1) == '\'') {
+					cur.append('\'');
+					i++;
+					continue;
+				}
+				cur.append(c);
+				continue;
+			}
+
+			if (c == '"' && !inSingle) {
+				inDouble = !inDouble;
+				continue;
+			}
+			if (allowSingle && c == '\'' && !inDouble) {
+				inSingle = !inSingle;
+				continue;
+			}
+
+			if (!inSingle && !inDouble && Character.isWhitespace(c)) {
+				if (cur.length() > 0) {
+					out.add(cur.toString());
+					cur.setLength(0);
+				}
+				continue;
+			}
+
+			cur.append(c);
+		}
+		if (cur.length() > 0) {
+			out.add(cur.toString());
+		}
+		return out;
 	}
 
 	private static boolean isWindows() {

--- a/src/main/java/org/mark/llamacpp/server/tools/CommandLineRunner.java
+++ b/src/main/java/org/mark/llamacpp/server/tools/CommandLineRunner.java
@@ -7,6 +7,8 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -327,13 +329,10 @@ public class CommandLineRunner {
 
 		if (os.contains("win")) {
 			pb.directory(exeDir);
-			String currentPath = env.get("PATH");
-			String dir = exeDir.getAbsolutePath();
-			if (currentPath == null || currentPath.isBlank()) {
-				env.put("PATH", dir);
-			} else if (!currentPath.contains(dir)) {
-				env.put("PATH", dir + ";" + currentPath);
-			}
+			List<String> paths = new ArrayList<>();
+			addExistingDir(paths, exeDir.getAbsolutePath());
+			addWindowsRocmDirs(paths);
+			prependWindowsPath(env, paths);
 			return;
 		}
 
@@ -426,6 +425,87 @@ public class CommandLineRunner {
 		if (exe == null) return false;
 		String lower = exe.toLowerCase(Locale.ROOT);
 		return lower.contains("rocm-smi") || lower.contains("rocm-");
+	}
+
+	private static void addWindowsRocmDirs(List<String> paths) {
+		File rocmRoot = new File("C:\\Program Files\\AMD\\ROCm");
+		File[] versions = rocmRoot.listFiles(File::isDirectory);
+		if (versions != null) {
+			Arrays.sort(versions, Comparator.comparing(File::getName).reversed());
+			for (File version : versions) {
+				addExistingDir(paths, new File(version, "bin").getAbsolutePath());
+				addExistingDir(paths, new File(version, "bin\\rocblas").getAbsolutePath());
+				addExistingDir(paths, new File(version, "bin\\hipblaslt").getAbsolutePath());
+			}
+		}
+
+		String[] fallbackRoots = {
+			"C:\\Program Files\\AMD\\AI_Bundle\\ROCm",
+			"C:\\Program Files\\AMD\\AI_Bundle"
+		};
+		for (String root : fallbackRoots) {
+			File dir = new File(root);
+			if (!dir.isDirectory()) {
+				continue;
+			}
+			addExistingDir(paths, new File(dir, "bin").getAbsolutePath());
+			addExistingDir(paths, new File(dir, "bin\\rocblas").getAbsolutePath());
+			addExistingDir(paths, new File(dir, "bin\\hipblaslt").getAbsolutePath());
+		}
+	}
+
+	private static void addExistingDir(List<String> paths, String path) {
+		if (path == null || path.isBlank()) {
+			return;
+		}
+		File dir = new File(path);
+		if (!dir.isDirectory()) {
+			return;
+		}
+		String abs = dir.getAbsolutePath();
+		for (String existing : paths) {
+			if (existing.equalsIgnoreCase(abs)) {
+				return;
+			}
+		}
+		paths.add(abs);
+	}
+
+	private static void prependWindowsPath(Map<String, String> env, List<String> paths) {
+		if (paths == null || paths.isEmpty()) {
+			return;
+		}
+		String key = findKeyIgnoreCase(env, "PATH");
+		String currentPath = key == null ? "" : env.getOrDefault(key, "");
+		StringBuilder merged = new StringBuilder();
+		for (String path : paths) {
+			if (containsWindowsPath(currentPath, path)) {
+				continue;
+			}
+			if (merged.length() > 0) {
+				merged.append(';');
+			}
+			merged.append(path);
+		}
+		if (currentPath != null && !currentPath.isBlank()) {
+			if (merged.length() > 0) {
+				merged.append(';');
+			}
+			merged.append(currentPath);
+		}
+		env.put(key == null ? "PATH" : key, merged.toString());
+	}
+
+	private static boolean containsWindowsPath(String pathList, String path) {
+		if (pathList == null || path == null) {
+			return false;
+		}
+		for (String entry : pathList.split(";")) {
+			if (entry.trim().equalsIgnoreCase(path)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private static boolean isWindows() {


### PR DESCRIPTION
## Summary
- Add Windows runtime PATH setup for llama.cpp subprocesses so ROCm DLLs are discoverable when launching from the hub.
- Apply the same PATH setup to command-based device probing, including `llama-bench --list-devices`.
- Default MTP speculative launches to `--parallel 1` when `--spec-type mtp` is used and no explicit parallel value is provided.

## Why
On Windows, ROCm builds can fail to enumerate AMD devices when launched by the hub because the child process does not inherit the ROCm runtime directories in `PATH`. Starting the same `llama-server.exe` from a wrapper script works, which points to process environment setup rather than the llama.cpp build itself.

MTP speculative decoding also currently requires single parallel mode. Without an explicit `--parallel 1`, `llama-server` may auto-select multiple parallel slots and fail during model load.

## Validation
- Installed JDK 21 and ran `javac-win.bat` successfully.
- Verified the hub's `CommandLineRunner` can run a ROCm `llama-bench.exe --list-devices` and detect `ROCm0: AMD Radeon(TM) 8060S Graphics`.
- Verified `LlamaCppProcess` can launch ROCm `llama-server.exe --list-devices` and detect the same ROCm device.
- Verified generated MTP launch commands include `--parallel 1` when `--spec-type mtp` is present.