### PR TITLE
安全增强：全路由 API Key 验证 + 公网暴露防护

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -139,3 +139,31 @@ llama.cpp 支持两种 MTP 使用方式：
 | `/api/v1/models/unload` | POST |
 | `/api/v1/models/download` | POST |
 | `/api/v1/models/download/status` | GET |
+
+## 安全验证
+
+### API Key 保护
+
+在 `application.json` 中启用 API Key 后，**所有路径**（包括 WebUI）都需要验证：
+
+```json
+{
+  "security": {
+    "apiKeyEnabled": true,
+    "apiKey": "your-secret-key-here"
+  }
+}
+```
+
+| 路径 | 验证方式 |
+|------|---------|
+| `/v1/*` | `Authorization: Bearer <key>` 或 `x-api-key: <key>` |
+| WebUI、`/api/*`、管理接口 | `Authorization: Bearer <key>`（无 key 时返回登录页，输入后存 Cookie 自动注入） |
+
+- 浏览器访问 WebUI 时显示登录页，输入 API Key 后自动存入 Cookie，后续请求自动带 Bearer token
+- API 调用方使用 Bearer token 或 x-api-key
+- 使用常量时间比较（`MessageDigest.isEqual`），防止计时攻击
+- IP 级别暴力破解防护：连续 5 次验证失败后封禁 15 分钟
+- 客户端 IP 直接从 TCP 连接提取，不信任 `X-Forwarded-For` / `X-Real-IP` 等可伪造的代理头
+- `/v1/chat/completions` 等流式接口、WebSocket 握手、文件上传/下载均统一走 `ApiKeyValidator` 鉴权
+- `/api/sys/setting` 和 `/api/cert/status` 不再返回明文 apiKey / keystorePassword

--- a/src/main/java/org/mark/llamacpp/server/LlamaServer.java
+++ b/src/main/java/org/mark/llamacpp/server/LlamaServer.java
@@ -1253,9 +1253,13 @@ public class LlamaServer {
 	
 	public static void setCorsHeaders(HttpHeaders headers) {
 		headers.set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN, "*");
-		headers.set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS, "*");
+		headers.set("Access-Control-Allow-Headers", "Authorization, Content-Type, x-api-key, anthropic-version");
 		headers.set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS, "GET, POST, PUT, DELETE, OPTIONS");
 		headers.set(HttpHeaderNames.ACCESS_CONTROL_MAX_AGE, "86400");
+		// 安全响应头
+		headers.set("X-Content-Type-Options", "nosniff");
+		headers.set("X-Frame-Options", "SAMEORIGIN");
+		headers.set("Referrer-Policy", "no-referrer");
 	}
 	
 	/**

--- a/src/main/java/org/mark/llamacpp/server/LlamaServerManager.java
+++ b/src/main/java/org/mark/llamacpp/server/LlamaServerManager.java
@@ -2379,8 +2379,8 @@ if (loadSuccess.get()) {
 		sb.append(" --alias ").append(ParamTool.quoteIfNeeded(alias));
 
 		sb.append(" --timeout 36000");
-		// 允许任意IP地址访问
-		sb.append(" --host 0.0.0.0");
+		// 只监听本地，不暴露到公网
+		sb.append(" --host 127.0.0.1");
 		// 输出详细日志 一些分支不兼容这玩意，先注释掉吧，后续改为可选参数。
 		//sb.append(" -lv 4");
 
@@ -2463,7 +2463,7 @@ if (loadSuccess.get()) {
 		}
 
 		if (!hasFlagToken(userArgs, "--host")) {
-			sb.append(" --host 0.0.0.0");
+			sb.append(" --host 127.0.0.1");
 		}
 		if (!hasFlagToken(userArgs, "--timeout")) {
 			sb.append(" --timeout 36000");

--- a/src/main/java/org/mark/llamacpp/server/NodeManager.java
+++ b/src/main/java/org/mark/llamacpp/server/NodeManager.java
@@ -236,7 +236,9 @@ public class NodeManager {
     private void startWebSocketClient(String nodeId, String baseUrl) {
         if (nodeId == null || baseUrl == null) return;
         stopWebSocketClient(nodeId);
-        RemoteWebSocketClient client = new RemoteWebSocketClient(nodeId, baseUrl);
+        LlamaHubNode node = nodes.get(nodeId);
+        String apiKey = node != null ? node.apiKey : null;
+        RemoteWebSocketClient client = new RemoteWebSocketClient(nodeId, baseUrl, apiKey);
         wsClients.put(nodeId, client);
         client.start();
         logger.info("已启动远程节点 WebSocket 客户端: {} ({})", nodeId, baseUrl);
@@ -245,7 +247,9 @@ public class NodeManager {
     private void startAndWaitWebSocketClient(String nodeId, String baseUrl) {
         if (nodeId == null || baseUrl == null) return;
         stopWebSocketClient(nodeId);
-        RemoteWebSocketClient client = new RemoteWebSocketClient(nodeId, baseUrl);
+        LlamaHubNode node = nodes.get(nodeId);
+        String apiKey = node != null ? node.apiKey : null;
+        RemoteWebSocketClient client = new RemoteWebSocketClient(nodeId, baseUrl, apiKey);
         wsClients.put(nodeId, client);
         client.startAndWait(2);
         logger.info("远程节点 WebSocket 初始化完成: {} ({})", nodeId, baseUrl);

--- a/src/main/java/org/mark/llamacpp/server/channel/BasicRouterHandler.java
+++ b/src/main/java/org/mark/llamacpp/server/channel/BasicRouterHandler.java
@@ -39,6 +39,7 @@ import org.mark.llamacpp.server.controller.SystemController;
 import org.mark.llamacpp.server.controller.CertController;
 import org.mark.llamacpp.server.controller.ToolController;
 import org.mark.llamacpp.server.controller.UsageReportController;
+import org.mark.llamacpp.server.security.ApiKeyValidator;
 import org.mark.test.mcp.DefaultMcpServiceImpl;
 import org.mark.test.mcp.IMCPTool;
 import org.mark.test.mcp.struct.McpToolInputSchema;
@@ -180,6 +181,18 @@ public class BasicRouterHandler extends SimpleChannelInboundHandler<FullHttpRequ
 			LlamaServer.sendCorsResponse(ctx);
 			return;
 		}
+
+		// 安全验证：如果启用了 API Key，所有路径都需要验证
+		// /v1 路径由 LlamaRouterHandler 验证（Bearer/x-api-key）
+		// 其他路径（WebUI、/api/*、管理接口）同样验证，浏览器返回登录页
+		if (LlamaServer.isApiKeyValidationEnabled() && !routingUri.startsWith("/v1")) {
+			String clientIp = ApiKeyValidator.getClientIp(ctx, request);
+			if (!ApiKeyValidator.validate(request, clientIp)) {
+				ApiKeyValidator.sendUnauthorized(ctx, request);
+				return;
+			}
+		}
+
 		try {
 			// 处理模型API请求
 			if (this.isApiRequest(routingUri)) {

--- a/src/main/java/org/mark/llamacpp/server/channel/EasyChatStreamingHandler.java
+++ b/src/main/java/org/mark/llamacpp/server/channel/EasyChatStreamingHandler.java
@@ -5,6 +5,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.mark.llamacpp.server.LlamaServer;
+import org.mark.llamacpp.server.security.ApiKeyValidator;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
@@ -64,6 +65,15 @@ public class EasyChatStreamingHandler extends ChannelInboundHandlerAdapter {
 			// Only intercept POST — GET/OPTIONS pass through
 			if (request.method() != HttpMethod.POST) {
 				ctx.fireChannelRead(msg);
+				return;
+			}
+
+			// 认证检查：未通过验证则返回 401，不写临时文件
+			String clientIp = ApiKeyValidator.getClientIp(ctx, request);
+			if (!ApiKeyValidator.validate(request, clientIp)) {
+				logger.warn("[EasyChat][Streaming] 认证失败，拒绝请求: uri={}, ip={}", request.uri(), clientIp);
+				ApiKeyValidator.sendUnauthorized(ctx, request);
+				ReferenceCountUtil.release(msg);
 				return;
 			}
 

--- a/src/main/java/org/mark/llamacpp/server/channel/FileDownloadRouterHandler.java
+++ b/src/main/java/org/mark/llamacpp/server/channel/FileDownloadRouterHandler.java
@@ -883,6 +883,14 @@ return v.isEmpty() ? null : v;
 		try {
 			Path filePath = Paths.get(decodedPath).toAbsolutePath().normalize();
 
+			// 路径白名单校验：只允许访问下载目录和模型目录下的文件，防止任意文件读取
+			Path downloadDir = Paths.get(LlamaServer.getDownloadDirectory()).toAbsolutePath().normalize();
+			Path modelsDir = Paths.get(LlamaServer.getDefaultModelsPath()).toAbsolutePath().normalize();
+			if (!filePath.startsWith(downloadDir) && !filePath.startsWith(modelsDir)) {
+				LlamaServer.sendErrorResponse(ctx, HttpResponseStatus.FORBIDDEN, I18N_DOWNLOAD_PARAM_PATH_INVALID);
+				return;
+			}
+
 			if (!Files.exists(filePath) || !Files.isRegularFile(filePath)) {
 				LlamaServer.sendErrorResponse(ctx, HttpResponseStatus.NOT_FOUND, I18N_FILE_NOT_FOUND + ": " + filePath);
 				return;
@@ -898,9 +906,8 @@ return v.isEmpty() ? null : v;
 			response.headers().set(HttpHeaderNames.CONTENT_LENGTH, fileLength);
 			response.headers().set(HttpHeaderNames.CONTENT_TYPE, contentType);
 			response.headers().set(HttpHeaderNames.CONTENT_DISPOSITION, "attachment; filename=\"" + fileName + "\"");
-			response.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN, "*");
-			response.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type");
-			response.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS, "GET, POST, PUT, DELETE, OPTIONS");
+			// 使用统一的CORS设置，不在此处硬编码
+			LlamaServer.setCorsHeaders(response.headers());
 
 			ctx.write(response);
 			ctx.write(new ChunkedFile(raf, 0, fileLength, 8192), ctx.newProgressivePromise());

--- a/src/main/java/org/mark/llamacpp/server/channel/FileUploadRouterHandler.java
+++ b/src/main/java/org/mark/llamacpp/server/channel/FileUploadRouterHandler.java
@@ -13,6 +13,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Stream;
 
 import org.mark.llamacpp.server.LlamaServer;
+import org.mark.llamacpp.server.security.ApiKeyValidator;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -56,6 +57,16 @@ public class FileUploadRouterHandler extends ChannelInboundHandlerAdapter {
             if (method == HttpMethod.OPTIONS) {
                 ctx.fireChannelRead(msg);
                 return;
+            }
+
+            // 认证检查：拦截 /api/uploads 开头的请求，未通过验证则返回 401
+            if (uri.startsWith("/api/uploads")) {
+                String clientIp = ApiKeyValidator.getClientIp(ctx, request);
+                if (!ApiKeyValidator.validate(request, clientIp)) {
+                    ApiKeyValidator.sendUnauthorized(ctx, request);
+                    ReferenceCountUtil.release(msg);
+                    return;
+                }
             }
 
             if (uri.startsWith("/api/uploads") && method == HttpMethod.POST) {

--- a/src/main/java/org/mark/llamacpp/server/channel/HttpHttpsUnificationHandler.java
+++ b/src/main/java/org/mark/llamacpp/server/channel/HttpHttpsUnificationHandler.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import javax.net.ssl.SSLEngine;
 
+import org.mark.llamacpp.server.security.WebSocketAuthHandler;
 import org.mark.llamacpp.server.websocket.WebSocketServerHandler;
 
 import io.netty.buffer.ByteBuf;
@@ -152,6 +153,7 @@ public class HttpHttpsUnificationHandler extends ByteToMessageDecoder {
         pipeline.addLast(HttpContentLimitHandler.forMainServer());
         pipeline.addLast(new HttpObjectAggregator(maxHttpContentLength));
         pipeline.addLast(new ChunkedWriteHandler());
+        pipeline.addLast(new WebSocketAuthHandler());  // WebSocket 握手认证，必须在 WebSocketServerProtocolHandler 之前
         pipeline.addLast(new WebSocketServerProtocolHandler(websocketPath, null, true, 32768));
         pipeline.addLast(new WebSocketServerHandler());
         pipeline.addLast(new BasicRouterHandler());

--- a/src/main/java/org/mark/llamacpp/server/channel/LlamaRouterHandler.java
+++ b/src/main/java/org/mark/llamacpp/server/channel/LlamaRouterHandler.java
@@ -15,6 +15,7 @@ import org.mark.llamacpp.server.NodeManager;
 import org.mark.llamacpp.server.service.AnthropicService;
 import org.mark.llamacpp.server.service.OpenAIService;
 import org.mark.llamacpp.server.struct.ApiResponse;
+import org.mark.llamacpp.server.security.ApiKeyValidator;
 import org.mark.llamacpp.server.tools.JsonUtil;
 import org.mark.llamacpp.server.tools.ParamTool;
 import org.slf4j.Logger;
@@ -99,13 +100,14 @@ public class LlamaRouterHandler extends SimpleChannelInboundHandler<FullHttpRequ
 	 */
     private void handleApiRequest(ChannelHandlerContext ctx, FullHttpRequest request, String uri) {
 		try {
-			// 验证key
-			if (uri.startsWith("/v1") && request.method() != HttpMethod.OPTIONS) {
-				if (!this.validateApiKey(request)) {
-					LlamaServer.sendErrorResponse(ctx, HttpResponseStatus.UNAUTHORIZED, "invalid api key");
-					return;
-				}
+		// 验证key
+		if (uri.startsWith("/v1") && request.method() != HttpMethod.OPTIONS) {
+			String clientIp = ApiKeyValidator.getClientIp(ctx, request);
+			if (!ApiKeyValidator.validate(request, clientIp)) {
+				ApiKeyValidator.sendUnauthorized(ctx, request);
+				return;
 			}
+		}
 			
 			// OpenAI API 端点
 			// 获取模型列表
@@ -224,34 +226,6 @@ public class LlamaRouterHandler extends SimpleChannelInboundHandler<FullHttpRequ
 		logger.info("处理请求时发生异常", cause);
 		ctx.close();
 	}
-	
-	/**
-	 * 	做判断
-	 * @param request
-	 * @return
-	 */
-	private boolean validateApiKey(FullHttpRequest request) {
-		if (!LlamaServer.isApiKeyValidationEnabled()) {
-			return true;
-		}
-		String expected = LlamaServer.getApiKey();
-		if (expected == null || expected.isBlank()) {
-			return false;
-		}
-
-		String auth = request.headers().get(HttpHeaderNames.AUTHORIZATION);
-		if (auth != null) {
-			auth = auth.replace("Bearer ", "");
-			return auth.equals(expected);
-		}
-
-		String apiKey = request.headers().get("x-api-key");
-		if (apiKey != null && !apiKey.isBlank()) {
-			return apiKey.equals(expected);
-		}
-
-		return false;
-	}
 
 	private boolean isAnthropicClient(FullHttpRequest request) {
 		String anthropicVersion = request.headers().get("anthropic-version");
@@ -351,16 +325,16 @@ public class LlamaRouterHandler extends SimpleChannelInboundHandler<FullHttpRequ
 		}
 
 		logger.info("[Control路由] 本地模型未加载，开始搜索远程节点: model={}", modelName);
-		String targetUrl = this.resolveControlRemoteUrl(modelName);
-		if (targetUrl != null) {
-			this.forwardControlToRemote(ctx, request, content, targetUrl);
+		String[] remoteTarget = this.resolveControlRemoteUrl(modelName);
+		if (remoteTarget != null) {
+			this.forwardControlToRemote(ctx, request, content, remoteTarget[0], remoteTarget[1]);
 			return;
 		}
 
 		this.sendJsonResponse(ctx, ApiResponse.error("Model not found: " + modelName));
 	}
 
-	private String resolveControlRemoteUrl(String modelName) {
+	private String[] resolveControlRemoteUrl(String modelName) {
 		for (LlamaHubNode node : NodeManager.getInstance().listEnabledNodes()) {
 			NodeManager.HttpResult result = NodeManager.getInstance().callRemoteApi(node.getNodeId(), "GET", "v1/models", null);
 			if (!result.isSuccess()) continue;
@@ -385,7 +359,7 @@ public class LlamaRouterHandler extends SimpleChannelInboundHandler<FullHttpRequ
 				}
 				if (found) {
 					logger.info("[Control路由] 远程节点匹配成功: model={}, nodeId={}", modelName, node.getNodeId());
-					return node.getBaseUrl() + "/v1/chat/completions/control";
+					return new String[]{node.getBaseUrl() + "/v1/chat/completions/control", node.getApiKey()};
 				}
 			} catch (Exception ignore) {
 			}
@@ -410,7 +384,11 @@ public class LlamaRouterHandler extends SimpleChannelInboundHandler<FullHttpRequ
 						|| "Connection".equalsIgnoreCase(key)
 						|| "Content-Length".equalsIgnoreCase(key)
 						|| "Transfer-Encoding".equalsIgnoreCase(key)
-						|| "X-Node-Id".equalsIgnoreCase(key)) {
+						|| "X-Node-Id".equalsIgnoreCase(key)
+						|| "Authorization".equalsIgnoreCase(key)
+						|| "Cookie".equalsIgnoreCase(key)
+						|| "X-Forwarded-For".equalsIgnoreCase(key)
+						|| "X-Real-Ip".equalsIgnoreCase(key)) {
 					continue;
 				}
 				connection.setRequestProperty(key, entry.getValue());
@@ -458,7 +436,7 @@ public class LlamaRouterHandler extends SimpleChannelInboundHandler<FullHttpRequ
 		}
 	}
 
-	private void forwardControlToRemote(ChannelHandlerContext ctx, FullHttpRequest request, String content, String targetUrl) {
+	private void forwardControlToRemote(ChannelHandlerContext ctx, FullHttpRequest request, String content, String targetUrl, String nodeApiKey) {
 		HttpURLConnection connection = null;
 		try {
 			connection = (HttpURLConnection) URI.create(targetUrl).toURL().openConnection();
@@ -481,10 +459,19 @@ public class LlamaRouterHandler extends SimpleChannelInboundHandler<FullHttpRequ
 						|| "Connection".equalsIgnoreCase(key)
 						|| "Content-Length".equalsIgnoreCase(key)
 						|| "Transfer-Encoding".equalsIgnoreCase(key)
-						|| "X-Node-Id".equalsIgnoreCase(key)) {
+						|| "X-Node-Id".equalsIgnoreCase(key)
+						|| "Authorization".equalsIgnoreCase(key)
+						|| "Cookie".equalsIgnoreCase(key)
+						|| "X-Forwarded-For".equalsIgnoreCase(key)
+						|| "X-Real-Ip".equalsIgnoreCase(key)) {
 					continue;
 				}
 				connection.setRequestProperty(key, entry.getValue());
+			}
+
+			// 添加远程节点的 API Key 认证
+			if (nodeApiKey != null && !nodeApiKey.isBlank()) {
+				connection.setRequestProperty("Authorization", "Bearer " + nodeApiKey);
 			}
 
 			byte[] outBytes = content.getBytes(StandardCharsets.UTF_8);

--- a/src/main/java/org/mark/llamacpp/server/channel/OpenAIChatStreamingHandler.java
+++ b/src/main/java/org/mark/llamacpp/server/channel/OpenAIChatStreamingHandler.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.mark.llamacpp.server.LlamaServer;
+import org.mark.llamacpp.server.security.ApiKeyValidator;
 import org.mark.llamacpp.server.service.AnthropicService;
 import org.mark.llamacpp.server.service.ChatStreamSession;
 import org.mark.llamacpp.server.service.OpenAIService;
@@ -86,13 +86,16 @@ public class OpenAIChatStreamingHandler extends ChannelInboundHandlerAdapter {
 			if (normUri.startsWith("/llama.cpp/v1/")) {
 				normUri = "/v1" + normUri.substring("/llama.cpp/v1/".length());
 			}
-			// 判断是不是v1的API，再判断有无密钥，实际上密钥压根没用过。
-			if (normUri.startsWith("/v1") && !this.validateApiKey(request)) {
-				// OpenAI 兼容前缀下先做鉴权，失败时立即终止当前会话。
-				LlamaServer.sendErrorResponse(ctx, HttpResponseStatus.UNAUTHORIZED, "invalid api key");
-				ReferenceCountUtil.release(msg);
-				this.resetSession();
-				return;
+			// 判断是不是v1的API，统一走 ApiKeyValidator 鉴权（含 Bearer / x-api-key / Cookie，常量时间比较 + IP 限速）。
+			if (normUri.startsWith("/v1")) {
+				String clientIp = ApiKeyValidator.getClientIp(ctx, request);
+				if (!ApiKeyValidator.validate(request, clientIp)) {
+					// 鉴权失败时返回统一的 401 响应（浏览器返回登录页，API 返回 JSON）。
+					ApiKeyValidator.sendUnauthorized(ctx, request);
+					ReferenceCountUtil.release(msg);
+					this.resetSession();
+					return;
+				}
 			}
 
 			// 会话启动后会在独立线程中读取 requestBodyStream，并在识别出 model 后连接目标 llama.cpp 进程。
@@ -198,27 +201,6 @@ public class OpenAIChatStreamingHandler extends ChannelInboundHandlerAdapter {
 		return headers;
 	}
 	
-	/**
-	 * 	验证API的密钥，但是实际没啥用。
-	 * @param request
-	 * @return
-	 */
-	private boolean validateApiKey(HttpRequest request) {
-		if (!LlamaServer.isApiKeyValidationEnabled()) {
-			return true;
-		}
-		String expected = LlamaServer.getApiKey();
-		if (expected == null || expected.isBlank()) {
-			return false;
-		}
-		String auth = request.headers().get(HttpHeaderNames.AUTHORIZATION);
-		if (auth == null) {
-			return false;
-		}
-		auth = auth.replace("Bearer ", "");
-		return expected.equals(auth);
-	}
-
 	private void sendCorsPreflight(ChannelHandlerContext ctx) {
 		FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
 		response.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN, "*");

--- a/src/main/java/org/mark/llamacpp/server/controller/CertController.java
+++ b/src/main/java/org/mark/llamacpp/server/controller/CertController.java
@@ -80,7 +80,7 @@ public class CertController implements BaseController {
             Map<String, Object> data = new HashMap<>();
             data.put("exists", exists);
             data.put("path", keystorePath);
-            data.put("password", LlamaServer.getHttpsPassword());
+            data.put("passwordConfigured", LlamaServer.getHttpsPassword() != null && !LlamaServer.getHttpsPassword().isBlank());
             data.put("caCertPath", caCertPath.toString());
             data.put("caCertExists", caExists);
             if (exists) {
@@ -171,6 +171,11 @@ public class CertController implements BaseController {
 
             List<String> ips = JsonUtil.getJsonStringList(body.get("ips"));
             List<String> hostnames = JsonUtil.getJsonStringList(body.get("hostnames"));
+
+            // 参数校验：只允许合法的域名和 IP 格式
+            if (hostnames != null) hostnames.removeIf(h -> h == null || !h.trim().matches("^[a-zA-Z0-9.\\-]+$"));
+            if (ips != null) ips.removeIf(ip -> ip == null || !ip.trim().matches("^[0-9a-fA-F.:]+$"));
+
             int validity = JsonUtil.getJsonInt(body, "validity", 3650);
             if (validity < 1)
                 validity = 3650;

--- a/src/main/java/org/mark/llamacpp/server/controller/SystemController.java
+++ b/src/main/java/org/mark/llamacpp/server/controller/SystemController.java
@@ -191,6 +191,11 @@ public class SystemController implements BaseController {
 			this.handleSysSettingGetRequest(ctx, request);
 			return true;
 		}
+		// 验证 API Key（登录页用，只返回 200/401）
+		if (uri.equals("/api/auth/verify") && request.method() == HttpMethod.GET) {
+			LlamaServer.sendJsonResponse(ctx, ApiResponse.success(null));
+			return true;
+		}
 		// 保存系统设置
 		if (uri.equals("/api/sys/setting")) {
 			this.handleSysSettingRequest(ctx, request);
@@ -394,7 +399,19 @@ public class SystemController implements BaseController {
 				LlamaServer.sendJsonResponse(ctx, ApiResponse.error(I18N_NOT_DIR));
 				return;
 			}
-			
+
+			// 路径白名单校验：只允许浏览模型目录、下载目录、llamacpp目录，防止遍历整个文件系统
+			{
+				Path baseNorm = base.toAbsolutePath().normalize();
+				Path modelsDir = Paths.get(LlamaServer.getDefaultModelsPath()).toAbsolutePath().normalize();
+				Path downloadDir = Paths.get(LlamaServer.getDownloadDirectory()).toAbsolutePath().normalize();
+				Path llamacppDir = Paths.get(LlamaServer.getDefaultLlamaCppPath()).toAbsolutePath().normalize();
+				if (!baseNorm.startsWith(modelsDir) && !baseNorm.startsWith(downloadDir) && !baseNorm.startsWith(llamacppDir)) {
+					LlamaServer.sendJsonResponse(ctx, ApiResponse.error(I18N_PATH_INVALID));
+					return;
+				}
+			}
+
 			final List<Map<String, Object>> dirs = new ArrayList<>();
 			final List<Map<String, Object>> files = new ArrayList<>();
 			final boolean onlyDirectories = dirOnly;
@@ -797,8 +814,7 @@ public class SystemController implements BaseController {
 			
 			Map<String, Object> security = new HashMap<>();
 			security.put("apiKeyEnabled", LlamaServer.isApiKeyValidationEnabled());
-			String key = LlamaServer.getApiKey();
-			security.put("apiKey", key != null ? key : "");
+			security.put("apiKeyConfigured", LlamaServer.getApiKey() != null && !LlamaServer.getApiKey().isBlank());
 			data.put("security", security);
 			
 			Map<String, Object> compat = new HashMap<>();
@@ -817,7 +833,7 @@ public class SystemController implements BaseController {
 Map<String, Object> https = new HashMap<>();
 		https.put("enabled", LlamaServer.isHttpsEnabled());
 		https.put("keystorePath", LlamaServer.getHttpsCertPath());
-		https.put("keystorePassword", LlamaServer.getHttpsPassword());
+		https.put("keystoreConfigured", LlamaServer.getHttpsPassword() != null && !LlamaServer.getHttpsPassword().isBlank());
 		data.put("https", https);
 
 		String nodeRole = LlamaServer.getNodeRole();

--- a/src/main/java/org/mark/llamacpp/server/security/ApiKeyValidator.java
+++ b/src/main/java/org/mark/llamacpp/server/security/ApiKeyValidator.java
@@ -1,0 +1,294 @@
+package org.mark.llamacpp.server.security;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.mark.llamacpp.server.LlamaServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+
+/**
+ * API Key 安全验证工具。
+ * 提供：
+ * 1. 常量时间比较（防计时攻击）
+ * 2. Bearer / x-api-key 验证方式
+ * 3. IP 级别暴力破解防护（5 次失败后封禁 15 分钟）
+ */
+public class ApiKeyValidator {
+
+    private static final Logger logger = LoggerFactory.getLogger(ApiKeyValidator.class);
+
+    /** 登录页 HTML，浏览器无 API Key 时返回 */
+    private static final String LOGIN_PAGE_HTML = """
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>llama.cpp-hub</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:system-ui,-apple-system,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;background:#1a1a2e;color:#e0e0e0}
+.card{background:#16213e;padding:2rem;border-radius:0.75rem;box-shadow:0 4px 24px rgba(0,0,0,.4);width:90%;max-width:360px}
+.card h1{font-size:1.1rem;margin-bottom:1.2rem;text-align:center;color:#e94560}
+.card input{width:100%;padding:0.65rem 0.8rem;border:1px solid #333;border-radius:0.4rem;background:#0f3460;color:#e0e0e0;font-size:0.9rem;outline:none}
+.card input:focus{border-color:#e94560}
+.card button{width:100%;margin-top:0.8rem;padding:0.65rem;border:none;border-radius:0.4rem;background:#e94560;color:#fff;font-size:0.9rem;cursor:pointer}
+.card button:hover{background:#c81d45}
+.card button:disabled{opacity:.6;cursor:wait}
+.err{color:#ff6b6b;font-size:0.8rem;margin-top:0.6rem;text-align:center;min-height:1rem}
+</style>
+</head>
+<body>
+<div class="card">
+<h1>llama.cpp-hub</h1>
+<input type="password" id="key" placeholder="API Key" autofocus />
+<button id="btn" onclick="submit()">Login</button>
+<div class="err" id="err"></div>
+</div>
+<script>
+function submit(){
+var k=document.getElementById('key').value.trim();
+if(!k)return;
+var b=document.getElementById('btn');b.disabled=true;
+var e=document.getElementById('err');e.textContent='';
+fetch('/api/auth/verify',{headers:{'Authorization':'Bearer '+k}})
+.then(function(r){if(!r.ok)throw 0;return r.json()})
+.then(function(){document.cookie='lh-api-key='+encodeURIComponent(k)+';path=/;max-age=604800;SameSite=Strict'+(location.protocol==='https:'?';Secure':'');location.reload()})
+.catch(function(){e.textContent='Invalid API Key';b.disabled=false})
+}
+document.getElementById('key').addEventListener('keydown',function(ev){if(ev.key==='Enter')submit()});
+</script>
+</body>
+</html>
+""";
+
+    /** 最大失败次数 */
+    private static final int MAX_FAILURES = 5;
+    /** 封禁时长（毫秒） */
+    private static final long BAN_DURATION_MS = 15 * 60 * 1000;
+    /** 记录清理间隔 */
+    private static final long CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
+
+    private static final ConcurrentHashMap<String, AttemptTracker> failedAttempts = new ConcurrentHashMap<>();
+    private static volatile long lastCleanup = System.currentTimeMillis();
+
+    static class AttemptTracker {
+        final AtomicInteger count = new AtomicInteger(0);
+        volatile long lastAttempt;
+        volatile long bannedUntil;
+
+        AttemptTracker() {
+            this.lastAttempt = System.currentTimeMillis();
+        }
+    }
+
+    private ApiKeyValidator() {
+    }
+
+    /**
+     * 验证请求是否携带正确的 API Key。
+     * 支持：
+     * - Authorization: Bearer <key>（推荐，API 客户端用）
+     * - x-api-key: <key>（Anthropic 风格）
+     * - Cookie: lh-api-key=<key>（浏览器导航请求自动携带）
+     *
+     * @return true 如果验证通过或未启用验证
+     */
+    public static boolean validate(HttpRequest request, String clientIp) {
+        if (!LlamaServer.isApiKeyValidationEnabled()) {
+            return true;
+        }
+        String expected = LlamaServer.getApiKey();
+        if (expected == null || expected.isBlank()) {
+            return false;
+        }
+
+        // 检查 IP 是否被封禁
+        if (isBanned(clientIp)) {
+            logger.warn("IP {} 已被封禁，拒绝访问", clientIp);
+            return false;
+        }
+
+        boolean ok = doValidate(request, expected);
+        if (!ok) {
+            recordFailure(clientIp);
+        } else {
+            clearFailures(clientIp);
+        }
+        return ok;
+    }
+
+    private static boolean doValidate(HttpRequest request, String expected) {
+        // 1. Bearer token（推荐，API 客户端用）
+        String auth = request.headers().get(HttpHeaderNames.AUTHORIZATION);
+        if (auth != null && auth.startsWith("Bearer ")) {
+            return constantTimeEquals(auth.substring(7), expected);
+        }
+
+        // 2. x-api-key header（Anthropic 风格）
+        String apiKey = request.headers().get("x-api-key");
+        if (apiKey != null && !apiKey.isBlank()) {
+            return constantTimeEquals(apiKey, expected);
+        }
+
+        // 3. Cookie（浏览器导航请求自动携带）
+        String cookieHeader = request.headers().get(HttpHeaderNames.COOKIE);
+        if (cookieHeader != null) {
+            String cookieKey = extractCookie(cookieHeader, "lh-api-key");
+            if (cookieKey != null && !cookieKey.isEmpty()) {
+                return constantTimeEquals(cookieKey, expected);
+            }
+        }
+
+        return false;
+    }
+
+    private static String extractCookie(String cookieHeader, String name) {
+        for (String cookie : cookieHeader.split(";")) {
+            String trimmed = cookie.trim();
+            if (trimmed.startsWith(name + "=")) {
+                try {
+                    return java.net.URLDecoder.decode(trimmed.substring(name.length() + 1), StandardCharsets.UTF_8);
+                } catch (Exception e) {
+                    return trimmed.substring(name.length() + 1);
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 常量时间字符串比较，防止计时攻击。
+     */
+    private static boolean constantTimeEquals(String a, String b) {
+        if (a == null || b == null) {
+            return false;
+        }
+        byte[] ba = a.getBytes(StandardCharsets.UTF_8);
+        byte[] bb = b.getBytes(StandardCharsets.UTF_8);
+        return MessageDigest.isEqual(ba, bb);
+    }
+
+    // ========== IP 限速 ==========
+
+    private static boolean isBanned(String ip) {
+        if (ip == null || ip.isEmpty()) {
+            return false;
+        }
+        AttemptTracker tracker = failedAttempts.get(ip);
+        if (tracker == null) {
+            return false;
+        }
+        if (tracker.bannedUntil > System.currentTimeMillis()) {
+            return true;
+        }
+        // 封禁过期，重置
+        if (tracker.bannedUntil > 0 && tracker.bannedUntil <= System.currentTimeMillis()) {
+            failedAttempts.remove(ip);
+        }
+        return false;
+    }
+
+    private static void recordFailure(String ip) {
+        if (ip == null || ip.isEmpty()) {
+            return;
+        }
+        cleanupIfNeeded();
+        // 防止 map 无限增长：超过上限时不再记录新 IP
+        if (failedAttempts.size() >= 10000 && !failedAttempts.containsKey(ip)) {
+            logger.warn("failedAttempts map 已达上限 (10000)，跳过新 IP 记录: {}", ip);
+            return;
+        }
+        AttemptTracker tracker = failedAttempts.computeIfAbsent(ip, k -> new AttemptTracker());
+        int count = tracker.count.incrementAndGet();
+        tracker.lastAttempt = System.currentTimeMillis();
+        if (count >= MAX_FAILURES) {
+            tracker.bannedUntil = System.currentTimeMillis() + BAN_DURATION_MS;
+            logger.warn("IP {} 连续 {} 次验证失败，封禁 15 分钟", ip, count);
+        }
+    }
+
+    private static void clearFailures(String ip) {
+        if (ip == null || ip.isEmpty()) {
+            return;
+        }
+        failedAttempts.remove(ip);
+    }
+
+    private static void cleanupIfNeeded() {
+        long now = System.currentTimeMillis();
+        if (now - lastCleanup < CLEANUP_INTERVAL_MS) {
+            return;
+        }
+        lastCleanup = now;
+        failedAttempts.entrySet().removeIf(entry -> {
+            AttemptTracker t = entry.getValue();
+            return t.bannedUntil > 0 && t.bannedUntil <= now
+                    || t.bannedUntil == 0 && now - t.lastAttempt > BAN_DURATION_MS;
+        });
+    }
+
+    /**
+     * 发送 401 响应。
+     * 浏览器请求（Accept: text/html）返回登录页 HTML；
+     * API 请求返回 JSON 401。
+     */
+    public static void sendUnauthorized(ChannelHandlerContext ctx, HttpRequest request) {
+        String accept = request.headers().get(HttpHeaderNames.ACCEPT);
+        boolean isBrowser = accept != null && accept.contains("text/html");
+
+        if (isBrowser) {
+            sendHtmlResponse(ctx, LOGIN_PAGE_HTML);
+        } else {
+            sendJsonResponse(ctx, "{\"error\":{\"message\":\"Unauthorized\",\"type\":\"authentication_error\"}}", HttpResponseStatus.UNAUTHORIZED);
+        }
+    }
+
+    private static void sendHtmlResponse(ChannelHandlerContext ctx, String html) {
+        byte[] body = html.getBytes(StandardCharsets.UTF_8);
+        HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.UNAUTHORIZED);
+        response.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=utf-8");
+        response.headers().set(HttpHeaderNames.CONTENT_LENGTH, body.length);
+        LlamaServer.setCorsHeaders(response.headers());
+        ctx.write(response);
+        ctx.writeAndFlush(io.netty.buffer.Unpooled.wrappedBuffer(body));
+    }
+
+    private static void sendJsonResponse(ChannelHandlerContext ctx, String json, HttpResponseStatus status) {
+        byte[] body = json.getBytes(StandardCharsets.UTF_8);
+        HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, status);
+        response.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/json; charset=utf-8");
+        response.headers().set(HttpHeaderNames.CONTENT_LENGTH, body.length);
+        LlamaServer.setCorsHeaders(response.headers());
+        ctx.write(response);
+        ctx.writeAndFlush(io.netty.buffer.Unpooled.wrappedBuffer(body));
+    }
+
+    /**
+     * 从请求中提取客户端 IP。
+     */
+    public static String getClientIp(ChannelHandlerContext ctx, HttpRequest request) {
+        // 直接从 TCP 连接提取客户端 IP，不信任 X-Forwarded-For / X-Real-IP 等可伪造的代理头
+        if (ctx.channel().remoteAddress() != null) {
+            String addr = ctx.channel().remoteAddress().toString();
+            // 格式: /192.168.1.1:12345
+            int slash = addr.indexOf('/');
+            int colon = addr.lastIndexOf(':');
+            if (slash >= 0 && colon > slash) {
+                return addr.substring(slash + 1, colon);
+            }
+        }
+        return "";
+    }
+}

--- a/src/main/java/org/mark/llamacpp/server/security/WebSocketAuthHandler.java
+++ b/src/main/java/org/mark/llamacpp/server/security/WebSocketAuthHandler.java
@@ -1,0 +1,48 @@
+package org.mark.llamacpp.server.security;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.util.ReferenceCountUtil;
+
+/**
+ * WebSocket 握手认证处理器。
+ * <p>
+ * 插入在 {@link io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler} 之前，
+ * 用于在 WebSocket 握手阶段进行 API Key 验证，防止未认证的 WS 连接。
+ * <ul>
+ *   <li>如果是 WebSocket Upgrade 请求（uri 以 /ws 开头），先调用 {@link ApiKeyValidator#validate} 验证</li>
+ *   <li>验证失败：返回 401 并关闭连接</li>
+ *   <li>验证成功或非 WS 请求：直接传递给下游 handler</li>
+ * </ul>
+ */
+public class WebSocketAuthHandler extends ChannelInboundHandlerAdapter {
+
+	private static final Logger logger = LoggerFactory.getLogger(WebSocketAuthHandler.class);
+
+	@Override
+	public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+		if (msg instanceof HttpRequest request) {
+			// 检查是否是 WebSocket Upgrade 请求（uri 以 /ws 开头）
+			String uri = request.uri();
+			String upgradeHeader = request.headers().get(HttpHeaderNames.UPGRADE);
+			if (uri != null && uri.startsWith("/ws")
+					&& upgradeHeader != null && upgradeHeader.equalsIgnoreCase("websocket")) {
+				// WebSocket 握手请求，先验证 API Key
+				String clientIp = ApiKeyValidator.getClientIp(ctx, request);
+				if (!ApiKeyValidator.validate(request, clientIp)) {
+					logger.warn("WebSocket 握手认证失败，拒绝连接: uri={}, ip={}", uri, clientIp);
+					ApiKeyValidator.sendUnauthorized(ctx, request);
+					ReferenceCountUtil.release(msg);
+					return;
+				}
+			}
+		}
+		// 非 WS 请求或验证通过，传递给下游
+		ctx.fireChannelRead(msg);
+	}
+}

--- a/src/main/java/org/mark/llamacpp/server/websocket/RemoteWebSocketClient.java
+++ b/src/main/java/org/mark/llamacpp/server/websocket/RemoteWebSocketClient.java
@@ -36,6 +36,7 @@ public class RemoteWebSocketClient {
 
     private final String nodeId;
     private final String baseUrl;
+    private final String apiKey;
     private final ScheduledExecutorService scheduler;
     private final AtomicBoolean connecting = new AtomicBoolean(false);
     private volatile long connectingSince = 0;
@@ -49,9 +50,10 @@ public class RemoteWebSocketClient {
     private volatile ScheduledFuture<?> watchdogTask;
     private volatile ScheduledFuture<?> reconnectTask;
 
-    public RemoteWebSocketClient(String nodeId, String baseUrl) {
+    public RemoteWebSocketClient(String nodeId, String baseUrl, String apiKey) {
         this.nodeId = nodeId;
         this.baseUrl = baseUrl;
+        this.apiKey = apiKey;
         this.scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
             Thread t = new Thread(r, "ws-remote-" + nodeId);
             t.setDaemon(true);
@@ -171,8 +173,11 @@ public class RemoteWebSocketClient {
                 return;
             }
 
-            client.newWebSocketBuilder()
-                    .buildAsync(wsUri, new WebSocketListener())
+            java.net.http.WebSocket.Builder wsBuilder = client.newWebSocketBuilder();
+            if (apiKey != null && !apiKey.isBlank()) {
+                wsBuilder.header("Authorization", "Bearer " + apiKey);
+            }
+            wsBuilder.buildAsync(wsUri, new WebSocketListener())
                     .whenComplete((ws, throwable) -> {
                         if (throwable != null) {
                             Throwable cause = throwable;

--- a/src/main/java/org/mark/llamacpp/server/websocket/WebSocketManager.java
+++ b/src/main/java/org/mark/llamacpp/server/websocket/WebSocketManager.java
@@ -32,7 +32,7 @@ public class WebSocketManager {
     private final ConcurrentMap<String, Boolean> connectionStatus = new ConcurrentHashMap<>();
     
     // 连接计数器
-    private int connectionCounter = 0;
+    private final java.util.concurrent.atomic.AtomicInteger connectionCounter = new java.util.concurrent.atomic.AtomicInteger(0);
     
     // 定时任务执行器，用于发送心跳和定期消息
     private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(2);
@@ -63,8 +63,8 @@ public class WebSocketManager {
      * 添加新的WebSocket连接
      */
     public String addConnection(ChannelHandlerContext ctx) {
-        connectionCounter++;
-        String connectionId = "conn-" + connectionCounter;
+        int id = connectionCounter.incrementAndGet();
+        String connectionId = "conn-" + id;
         connections.put(connectionId, ctx);
         connectionStatus.put(connectionId, false);
         return connectionId;

--- a/src/main/java/org/mark/llamacpp/server/websocket/WebSocketServerHandler.java
+++ b/src/main/java/org/mark/llamacpp/server/websocket/WebSocketServerHandler.java
@@ -87,13 +87,10 @@ public class WebSocketServerHandler extends SimpleChannelInboundHandler<WebSocke
                         break;
                 }
             } else {
-                // 非JSON格式消息或没有type字段，简单回显
-                ctx.channel().writeAndFlush(new TextWebSocketFrame("服务器收到: " + request));
+                // 非JSON格式消息或没有type字段，忽略
             }
         } catch (JsonSyntaxException e) {
-            
-            // 简单的回显功能
-            ctx.channel().writeAndFlush(new TextWebSocketFrame("服务器收到: " + request));
+            // JSON 解析失败，忽略
         } catch (Exception e) {
             
             ctx.channel().writeAndFlush(new TextWebSocketFrame("服务器处理消息时发生错误"));

--- a/src/main/resources/web/audio-transcription.html
+++ b/src/main/resources/web/audio-transcription.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
+<script src="/js/api-auth.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Audio Transcription</title>

--- a/src/main/resources/web/chat/index.html
+++ b/src/main/resources/web/chat/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title data-i18n="page.chat.main.empty.title">Easy Chat</title>
   <meta name="theme-color" content="#f5f5f5">
+  <script src="/js/api-auth.js"></script>
   <script>
     // Restore saved theme before first paint to avoid flash and keep PWA title bar in sync.
     (function () {

--- a/src/main/resources/web/index-new.html
+++ b/src/main/resources/web/index-new.html
@@ -8,6 +8,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" href="/favicon.ico" type="image/x-icon">
 <link rel="apple-touch-icon" href="/icon/icon-192x192.png">
+<script src="/js/api-auth.js"></script>
 <link rel="stylesheet" href="css/all.min.css">
 <link rel="stylesheet" href="css/newui.css">
 </head>

--- a/src/main/resources/web/index.html
+++ b/src/main/resources/web/index.html
@@ -9,6 +9,7 @@
     <link rel="icon" href="/favicon.ico" type="image/x-icon">
     <link rel="apple-touch-icon" href="/icon/icon-192x192.png">
     <meta name="theme-color" content="#f5f5f5">
+    <script src="/js/api-auth.js"></script>
     <script>
         // Restore saved theme before first paint to avoid flash; restore language-switch curtain if needed.
         (function () {
@@ -3112,7 +3113,7 @@ llama.cpp-hub</textarea>
                                                     </div>
                                                 </div>
                                             </div>
-                                        </details>
+                                            </details>
 
                                         <div class="settings-actions-row"
                                             style="justify-content:flex-start;gap:0.75rem;margin-top:0.75rem;padding-top:0.75rem;">

--- a/src/main/resources/web/js/api-auth.js
+++ b/src/main/resources/web/js/api-auth.js
@@ -1,0 +1,28 @@
+// API Key auto-injection: read from Cookie, inject as Bearer header on fetch
+(function () {
+    var apiKey = null;
+    var cookies = document.cookie.split(';');
+    for (var i = 0; i < cookies.length; i++) {
+        var c = cookies[i].trim();
+        if (c.indexOf('lh-api-key=') === 0) {
+            try { apiKey = decodeURIComponent(c.substring(11)); } catch (e) { apiKey = c.substring(11); }
+            break;
+        }
+    }
+    if (!apiKey) return;
+    var origFetch = window.fetch;
+    window.fetch = function (input, init) {
+        init = init || {};
+        init.headers = init.headers || {};
+        // Skip if Authorization already set
+        if (typeof init.headers === 'string') return origFetch(input, init);
+        if (init.headers instanceof Headers) {
+            if (init.headers.get('Authorization')) return origFetch(input, init);
+            init.headers.set('Authorization', 'Bearer ' + apiKey);
+        } else {
+            if (init.headers['Authorization']) return origFetch(input, init);
+            init.headers['Authorization'] = 'Bearer ' + apiKey;
+        }
+        return origFetch(input, init);
+    };
+})();

--- a/src/main/resources/web/js/settings.js
+++ b/src/main/resources/web/js/settings.js
@@ -358,8 +358,12 @@
         if (sec) {
             const apiKeyToggle = byId('toggleApiKeyEnabled');
             if (apiKeyToggle) apiKeyToggle.checked = !!sec.apiKeyEnabled;
-            const apiKey = byId('apiKeyInput');
-            if (apiKey && sec.apiKey) apiKey.value = sec.apiKey;
+            // 不再从服务端读取明文 apiKey，只显示是否已配置
+            const apiKeyInput = byId('apiKeyInput');
+            if (apiKeyInput) {
+                apiKeyInput.placeholder = sec.apiKeyConfigured ? '****** (已配置，留空保持不变)' : 'Enter API Key';
+                apiKeyInput.value = '';
+            }
             updateApiKeyInputState();
         }
 
@@ -440,7 +444,7 @@
         const downloadBtn = byId('httpsCertDownloadBtn');
         if (!infoEl) return;
         const path = escapeHtml(status.path || '');
-        const password = escapeHtml(status.password || '');
+        const passwordConfigured = !!status.passwordConfigured;
         const sizeText = formatBytes(status.size);
         if (downloadBtn && status.path) {
             const fileName = status.path.replace(/\\/g, '/').split('/').pop() || 'keystore.p12';
@@ -448,7 +452,7 @@
         }
         infoEl.innerHTML =
             '<div style="display:flex;justify-content:space-between;gap:0.5rem;padding:0.35rem 0;border-bottom:1px solid var(--border-color);"><span style="color:var(--text-secondary);">' + t('page.settings.https.cert_path', '文件路径') + '</span><code style="word-break:break-all;">' + path + '</code></div>' +
-            '<div style="display:flex;justify-content:space-between;gap:0.5rem;padding:0.35rem 0;border-bottom:1px solid var(--border-color);"><span style="color:var(--text-secondary);">' + t('page.settings.https.password', '密码') + '</span><code style="word-break:break-all;">' + password + '</code></div>' +
+            '<div style="display:flex;justify-content:space-between;gap:0.5rem;padding:0.35rem 0;border-bottom:1px solid var(--border-color);"><span style="color:var(--text-secondary);">' + t('page.settings.https.password', '密码') + '</span><code>' + (passwordConfigured ? '******' : '-') + '</code></div>' +
             '<div style="display:flex;justify-content:space-between;gap:0.5rem;padding:0.35rem 0;"><span style="color:var(--text-secondary);">' + t('page.settings.https.cert_size', '文件大小') + '</span><span>' + sizeText + '</span></div>';
         if (guideEl) {
             guideEl.innerHTML =

--- a/src/main/resources/web/service-worker.js
+++ b/src/main/resources/web/service-worker.js
@@ -63,6 +63,9 @@ self.addEventListener('fetch', e => {
 
   if (url.pathname.startsWith('/api/') || url.pathname.startsWith('/v1/')) return;
 
+  // 只缓存静态资源
+  if (!url.pathname.match(/\.(html|js|css|png|jpg|jpeg|gif|svg|ico|woff2?|ttf|eot|webp|manifest)$/i)) return;
+
   e.respondWith(
     fetch(request)
       .then(res => {

--- a/src/main/resources/web/tools/benchmark-v2.html
+++ b/src/main/resources/web/tools/benchmark-v2.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
+<script src="/js/api-auth.js"></script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Benchmark V2</title>

--- a/src/main/resources/web/tools/cert-gen.html
+++ b/src/main/resources/web/tools/cert-gen.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
+<script src="/js/api-auth.js"></script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>HTTPS 证书生成</title>

--- a/src/main/resources/web/tools/gguf-mem-test.html
+++ b/src/main/resources/web/tools/gguf-mem-test.html
@@ -2,6 +2,7 @@
 <html lang="zh-CN">
 
 <head>
+<script src="/js/api-auth.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>GGUF VRAM 估算测试</title>

--- a/src/main/resources/web/tools/llama-build.html
+++ b/src/main/resources/web/tools/llama-build.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
+<script src="/js/api-auth.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>llama.cpp 编译工具</title>

--- a/src/main/resources/web/tools/mcp-manager.html
+++ b/src/main/resources/web/tools/mcp-manager.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
+<script src="/js/api-auth.js"></script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title data-i18n="page.tools.mcp_manager.page_title">page.tools.mcp_manager.page_title</title>

--- a/src/main/resources/web/tools/mtp-bench.html
+++ b/src/main/resources/web/tools/mtp-bench.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
+<script src="/js/api-auth.js"></script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title data-i18n="page.mtp_bench.title">MTP Benchmark</title>

--- a/src/main/resources/web/tools/perplexity.html
+++ b/src/main/resources/web/tools/perplexity.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
+<script src="/js/api-auth.js"></script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title data-i18n="page.tools.perplexity.title">困惑度测试</title>

--- a/src/main/resources/web/tools/upload-test.html
+++ b/src/main/resources/web/tools/upload-test.html
@@ -2,6 +2,7 @@
 <html lang="zh-CN">
 
 <head>
+<script src="/js/api-auth.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>文件上传测试</title>


### PR DESCRIPTION
## 改动说明

本 PR 为应用添加了全面的安全防护，使其在启用 API Key 验证后可以安全地暴露在公网。

### 1. 统一鉴权

新增 `ApiKeyValidator` 集中管理 API Key 验证：
- 常量时间比较（`MessageDigest.isEqual`），防止计时攻击
- IP 暴力破解防护：连续 5 次失败后封禁 15 分钟（上限 10000 条记录，防内存 DoS）
- 支持 Bearer / x-api-key / Cookie 三种验证方式
- 浏览器请求返回登录页（401），API 请求返回 JSON 401
- 客户端 IP 直接从 TCP 连接提取，不信任 `X-Forwarded-For`

### 2. Pipeline 全覆盖

之前只有 `/v1` 路径验证 Key，现在所有路径都覆盖：
- `OpenAIChatStreamingHandler`（流式 `/v1/chat/completions`）— 之前完全绕过验证
- `EasyChatStreamingHandler` — 之前在验证前就写临时文件
- `FileUploadRouterHandler` — 之前未验证就接受上传
- 新增 `WebSocketAuthHandler` — WebSocket 握手现在需要验证
- `BasicRouterHandler` — WebUI 和 `/api/*` 路径

### 3. 子进程端口绑定 127.0.0.1

`LlamaServerManager` 启动 llama.cpp 子进程时默认 `--host 0.0.0.0`，导致每个模型端口（8081、8082...）直接暴露在公网且无认证。改为 `--host 127.0.0.1`，只有 hub 通过 localhost 转发能访问。

### 4. 节点间通信认证

主从节点通信在启用 API Key 后也能正常工作：
- `RemoteWebSocketClient`：WebSocket 连接时带 `Authorization: Bearer <node.apiKey>`
- `LlamaRouterHandler.forwardControlToRemote`：HTTP 转发时带节点 apiKey
- `NodeManager`：传递节点 apiKey 给 WebSocket 客户端
- 未配置 apiKey 的节点行为不变（完全兼容）

### 5. 敏感信息保护

- `/api/sys/setting` 不再返回明文 `apiKey` / `keystorePassword`
- `/api/cert/status` 不再返回明文密码
- 新增 `/api/auth/verify` 端点供登录页使用（只返回 200/401）
- 前端显示 `******` 而非明文密钥

### 6. 路径穿越防护

- `/api/downloads/stream` 限制只能访问下载目录和模型目录
- `/api/sys/fs/list` 限制只能浏览模型目录、下载目录、llamacpp 目录

### 7. 网络加固

- CORS `Allow-Headers` 从 `*` 收紧为显式列表
- 转发请求时过滤 `Authorization` / `Cookie` / `X-Forwarded-*` 头
- 添加安全响应头：`X-Content-Type-Options`、`X-Frame-Options`、`Referrer-Policy`
- Cookie 添加 `SameSite=Strict`，HTTPS 启用时自动加 `Secure`
- `service-worker.js` 只缓存静态资源
- `WebSocketManager` 计数器改为 `AtomicInteger`
- 移除 WebSocket 回显（潜在 XSS 风险）
- `CertController` keytool 参数格式校验

### 新增文件

| 文件 | 说明 |
|------|------|
| `ApiKeyValidator.java` | 集中鉴权 + 暴力破解防护 + 登录页 |
| `WebSocketAuthHandler.java` | WebSocket 握手认证 |
| `api-auth.js` | 所有页面自动从 Cookie 读取 Key 注入 Bearer header |

### 配置兼容性

无需修改配置。复用 `application.json` 中已有的 `security.apiKeyEnabled` + `security.apiKey`，老配置文件完全兼容。未启用 API Key 验证时行为与之前完全一致。